### PR TITLE
Update celestite_amber_init.example.cr

### DIFF
--- a/config/celestite_amber_init.example.cr
+++ b/config/celestite_amber_init.example.cr
@@ -10,7 +10,7 @@ celestite_logger.color = :green
 
 # The main init...
 
-Celestite.init(
+Celestite.initialize(
 
   # #
   # # First, choose your engine.


### PR DESCRIPTION
To Avoid this 
```
In config/initializers/celestite_amber_init.cr:13:11

 13 | Celestite.init(
                ^---
Error: undefined method 'init' for Celestite:Module
04:45:55 Watch run  | (INFO) Compile time errors detected, exiting...
```